### PR TITLE
[1] fix(1500): Add screwdriver.yaml

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -1,0 +1,15 @@
+shared:
+    image: node:8
+    steps:
+        - create-artifacts: |
+           echo -n '{"name": "sample text 1"}' > ${SD_ARTIFACTS_DIR}/sample1.txt
+           echo -n '{"name": "sample text 2"}' > ${SD_ARTIFACTS_DIR}/sample2.txt
+jobs:
+    main:
+        requires: [~pr, ~commit]
+        environment:
+             SD_ZIP_ARTIFACTS: false
+    ziped:
+        requires: [~pr, ~commit]
+        environment:
+             SD_ZIP_ARTIFACTS: true

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -1,5 +1,5 @@
 shared:
-    image: node:8
+    image: node:14
     steps:
         - create-artifacts: |
            echo -n '{"name": "sample text 1"}' > ${SD_ARTIFACTS_DIR}/sample1.txt

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -9,7 +9,7 @@ jobs:
         requires: [~pr, ~commit]
         environment:
              SD_ZIP_ARTIFACTS: false
-    ziped:
+    zipped:
         requires: [~pr, ~commit]
         environment:
              SD_ZIP_ARTIFACTS: true


### PR DESCRIPTION
# Context
With the reimplementation of SD_ZIP_ARTIFACTS, we will add a pipeline to functional tests on artifact features.
The implementation of the functional test itself will be done in [this PR](https://github.com/screwdriver-cd/screwdriver/pull/2594).

# Objective
Add screwdriver.yaml.
This pipeline will run when the SD_ZIP_ARTIFACTS feature is enabled and disabled respectively.

# Reference
https://github.com/screwdriver-cd/screwdriver/issues/1500